### PR TITLE
aarch64: cloud hypervisor works from command line

### DIFF
--- a/host/initramfs/Makefile
+++ b/host/initramfs/Makefile
@@ -62,6 +62,7 @@ build/live.img: $(SCRIPTS)/format-uuid.sh $(SCRIPTS)/make-gpt.sh build/rootfs.ve
 clean:
 	rm -rf build
 .PHONY: clean
+extfs: $(EXT_FS)
 
 run: build/initramfs build/rootfs.verity.roothash build/live.img
 	$(QEMU_KVM) -m 4G \

--- a/host/rootfs/Makefile
+++ b/host/rootfs/Makefile
@@ -8,9 +8,10 @@ QEMU_KVM = qemu-kvm
 
 # tar2ext4 will leave half a filesystem behind if it's interrupted
 # half way through.
-build/rootfs.ext4: build/rootfs.tar
+build/rootfs.ext4: build/rootfs.tar $(EXT_FS)
 	tar2ext4 -i build/rootfs.tar -o $@.tmp
 	mv $@.tmp $@
+	cp -f $(EXT_FS) build/extfs.ext4
 
 FILES = \
 	etc/fonts/fonts.conf \
@@ -116,7 +117,7 @@ clean:
 	rm -rf build
 .PHONY: clean
 
-run: build/rootfs.ext4 $(EXT_FS)
+run: build/rootfs.ext4
 	$(QEMU_KVM) -cpu host -m 2G \
 	    -machine q35,kernel=$(KERNEL),kernel-irqchip=split \
 	    -display gtk,gl=on \

--- a/host/rootfs/default.nix
+++ b/host/rootfs/default.nix
@@ -52,6 +52,8 @@ let
 
   kernel = pkgs.linux_imx8.override {
     structuredExtraConfig = with lib.kernel; {
+      EFI_STUB=yes;
+      EFI=yes;
       VIRTIO = yes;
       VIRTIO_PCI = yes;
       VIRTIO_BLK = yes;

--- a/host/start-vm/start-vm.rs
+++ b/host/start-vm/start-vm.rs
@@ -29,7 +29,7 @@ fn vm_command(dir: PathBuf) -> Result<Command, String> {
     command.args(&["-dc", "test -S env/cloud-hypervisor.sock"]);
     command.arg("cloud-hypervisor");
     command.args(&["--api-socket", "env/cloud-hypervisor.sock"]);
-    command.args(&["--cmdline", "console=ttyS0 root=/dev/vda"]);
+    command.args(&["--cmdline", "console=hvc0 root=/dev/vda"]);
     command.args(&["--memory", "size=128M"]);
     command.args(&["--console", "pty"]);
 
@@ -72,7 +72,7 @@ fn vm_command(dir: PathBuf) -> Result<Command, String> {
     command.arg("--kernel").arg({
         let mut kernel = OsString::from("/ext/svc/data/");
         kernel.push(&vm_name);
-        kernel.push("/vmlinux");
+        kernel.push("/Image");
         kernel
     });
 

--- a/vm/app/catgirl/Makefile
+++ b/vm/app/catgirl/Makefile
@@ -13,7 +13,7 @@ HOST_FILES = host/data/appvm-catgirl/providers/net/netvm
 
 HOST_BUILD_FILES = \
 	build/host/data/appvm-catgirl/rootfs.ext4 \
-	build/host/data/appvm-catgirl/vmlinux
+	build/host/data/appvm-catgirl/Image
 
 # We produce a directory, but that doesn't play nice with Make,
 # because it won't know to update if some file in the directory is
@@ -29,9 +29,9 @@ build/svc: $(HOST_FILES) $(HOST_BUILD_FILES)
 	tar -c $(HOST_FILES) | tar -C $@ -x --strip-components 1
 	tar -c $(HOST_BUILD_FILES) | tar -C $@ -x --strip-components 2
 
-build/host/data/appvm-catgirl/vmlinux: $(VMLINUX)
+build/host/data/appvm-catgirl/Image: $(IMAGE)
 	mkdir -p $$(dirname $@)
-	cp $(VMLINUX) $@
+	cp $(IMAGE) $$(dirname $@)/Image
 
 # tar2ext4 will leave half a filesystem behind if it's interrupted
 # half way through.

--- a/vm/app/catgirl/default.nix
+++ b/vm/app/catgirl/default.nix
@@ -47,8 +47,10 @@ let
         -T ${writeReferencesToFile packagesSysroot} .
   '';
 
-  kernel = buildPackages.linux.override {
+  kernel = pkgs.linux_hardened.override {
     structuredExtraConfig = with lib.kernel; {
+      EFI_STUB=yes;
+      EFI=yes;
       VIRTIO = yes;
       VIRTIO_PCI = yes;
       VIRTIO_BLK = yes;
@@ -75,6 +77,7 @@ stdenvNoCC.mkDerivation {
 
   PACKAGES_TAR = packagesTar;
   VMLINUX = "${kernel.dev}/vmlinux";
+  IMAGE = "${kernel}/Image";
 
   installPhase = ''
     mv build/svc $out

--- a/vm/app/catgirl/default.nix
+++ b/vm/app/catgirl/default.nix
@@ -47,7 +47,7 @@ let
         -T ${writeReferencesToFile packagesSysroot} .
   '';
 
-  kernel = pkgs.linux_hardened.override {
+  kernel = pkgs.linux_latest.override {
     structuredExtraConfig = with lib.kernel; {
       EFI_STUB=yes;
       EFI=yes;

--- a/vm/app/lynx/Makefile
+++ b/vm/app/lynx/Makefile
@@ -13,7 +13,7 @@ HOST_FILES = host/data/appvm-lynx/providers/net/netvm
 
 HOST_BUILD_FILES = \
 	build/host/data/appvm-lynx/rootfs.ext4 \
-	build/host/data/appvm-lynx/vmlinux
+	build/host/data/appvm-lynx/Image
 
 # We produce a directory, but that doesn't play nice with Make,
 # because it won't know to update if some file in the directory is
@@ -29,9 +29,9 @@ build/svc: $(HOST_FILES) $(HOST_BUILD_FILES)
 	tar -c $(HOST_FILES) | tar -C $@ -x --strip-components 1
 	tar -c $(HOST_BUILD_FILES) | tar -C $@ -x --strip-components 2
 
-build/host/data/appvm-lynx/vmlinux: $(VMLINUX)
+build/host/data/appvm-lynx/Image: $(IMAGE)
 	mkdir -p $$(dirname $@)
-	cp $(VMLINUX) $@
+	cp $(IMAGE) $$(dirname $@)/Image
 
 # tar2ext4 will leave half a filesystem behind if it's interrupted
 # half way through.

--- a/vm/app/lynx/default.nix
+++ b/vm/app/lynx/default.nix
@@ -47,8 +47,10 @@ let
         -T ${writeReferencesToFile packagesSysroot} .
   '';
 
-  kernel = buildPackages.linux.override {
+  kernel = pkgs.linux_hardened.override {
     structuredExtraConfig = with lib.kernel; {
+      EFI_STUB=yes;
+      EFI=yes;
       VIRTIO = yes;
       VIRTIO_PCI = yes;
       VIRTIO_BLK = yes;
@@ -75,6 +77,7 @@ stdenvNoCC.mkDerivation {
 
   PACKAGES_TAR = packagesTar;
   VMLINUX = "${kernel.dev}/vmlinux";
+  IMAGE = "${kernel}/Image";
 
   installPhase = ''
     mv build/svc $out

--- a/vm/app/lynx/default.nix
+++ b/vm/app/lynx/default.nix
@@ -47,7 +47,7 @@ let
         -T ${writeReferencesToFile packagesSysroot} .
   '';
 
-  kernel = pkgs.linux_hardened.override {
+  kernel = pkgs.linux_latest.override {
     structuredExtraConfig = with lib.kernel; {
       EFI_STUB=yes;
       EFI=yes;

--- a/vm/sys/net/Makefile
+++ b/vm/sys/net/Makefile
@@ -11,7 +11,7 @@ VMM = qemu
 
 HOST_BUILD_FILES = \
 	build/host/data/netvm/rootfs.ext4 \
-	build/host/data/netvm/vmlinux
+	build/host/data/netvm/Image
 
 # We produce a directory, but that doesn't play nice with Make,
 # because it won't know to update if some file in the directory is
@@ -26,9 +26,9 @@ build/svc: $(HOST_BUILD_FILES)
 
 	tar -c $(HOST_BUILD_FILES) | tar -C $@ -x --strip-components 2
 
-build/host/data/netvm/vmlinux: $(VMLINUX)
+build/host/data/netvm/Image: $(IMAGE)
 	mkdir -p $$(dirname $@)
-	cp $(VMLINUX) $@
+	cp $(IMAGE) $$(dirname $@)/Image
 
 # tar2ext4 will leave half a filesystem behind if it's interrupted
 # half way through.

--- a/vm/sys/net/default.nix
+++ b/vm/sys/net/default.nix
@@ -56,8 +56,10 @@ let
         -T ${writeReferencesToFile packagesSysroot} .
   '';
 
-  kernel = buildPackages.linux.override {
+  kernel = pkgs.linux_hardened.override {
     structuredExtraConfig = with lib.kernel; {
+      EFI_STUB=yes;
+      EFI=yes;
       VIRTIO = yes;
       VIRTIO_PCI = yes;
       VIRTIO_BLK = yes;
@@ -84,6 +86,7 @@ stdenvNoCC.mkDerivation {
 
   PACKAGES_TAR = packagesTar;
   VMLINUX = "${kernel.dev}/vmlinux";
+  IMAGE = "${kernel}/Image";
 
   installPhase = ''
     mv build/svc $out

--- a/vm/sys/net/default.nix
+++ b/vm/sys/net/default.nix
@@ -56,7 +56,7 @@ let
         -T ${writeReferencesToFile packagesSysroot} .
   '';
 
-  kernel = pkgs.linux_hardened.override {
+  kernel = pkgs.linux_latest.override {
     structuredExtraConfig = with lib.kernel; {
       EFI_STUB=yes;
       EFI=yes;


### PR DESCRIPTION
Virtual machines can be started from the command line, e.g.: 
cloud-hypervisor --cmdline "console=hvc0 root=/dev/vda" --memory "size=8128M" "--console" "pty" "--kernel" /ext/svc/data/appvm-catgirl/Image  "--disk" "path=/ext/svc/data/appvm-catgirl/rootfs.ext4" -v 


Starting the application machines by the vm-start command works properly. Used the NXP kernel build.