### PR TITLE
imx8-linux-hardened: add missing configurations

### DIFF
--- a/host/rootfs/generated_arm64_imx8qmmek_kvm-nixos_host_release_defconfig
+++ b/host/rootfs/generated_arm64_imx8qmmek_kvm-nixos_host_release_defconfig
@@ -1795,3 +1795,6 @@ CONFIG_VSOCKETS_DIAG=y
 CONFIG_VHOST_VSOCK=y
 CONFIG_VHOST=y
 CONFIG_FORTIFY_SOURCE=n # XXX: drivers cannot commpile if enabled
+
+CONFIG_CMDLINE="console=ttyLP0,115200 console=tty1 earlycon root=/dev/mmcblk1p2 rootfstype=ext4 rootwait rw quiet selinux=1 enforcing=0"
+CONFIG_DM_VERITY=y


### PR DESCRIPTION
dm-verity and default linux command line is needed
to allow booting Spectrum OS in imx8.

Signed-off-by: José Pekkarinen <jose.pekkarinen@unikie.com>