### PR TITLE
Get rid of default modules since many of them are not enable in imx8 defconfig

### DIFF
--- a/host/initramfs/default.nix
+++ b/host/initramfs/default.nix
@@ -17,8 +17,7 @@ let
 
   modules = makeModulesClosure {
     inherit (rootfs) firmware kernel;
-    rootModules = with rootfs.nixosAllHardware.config.boot.initrd;
-      availableKernelModules ++ kernelModules ++ [ "dm-verity" "loop" ];
+    rootModules = [ "dm-verity" "loop" ];
   };
 
   packages = [


### PR DESCRIPTION
Signed-off-by: Yuri Nesterov <yuriy.nesterov@unikie.com>