### PR TITLE
Initial kvms integration

### DIFF
--- a/host/rootfs/default.nix
+++ b/host/rootfs/default.nix
@@ -50,7 +50,7 @@ let
     imports = [ (modulesPath + "/profiles/all-hardware.nix") ];
   });
 
-  kernel = pkgs.linux_imx8_kvmsed.override {
+  kernel = pkgs.linux_imx8.override {
     structuredExtraConfig = with lib.kernel; {
       EFI_STUB=yes;
       EFI=yes;

--- a/host/rootfs/default.nix
+++ b/host/rootfs/default.nix
@@ -50,7 +50,7 @@ let
     imports = [ (modulesPath + "/profiles/all-hardware.nix") ];
   });
 
-  kernel = pkgs.linux_imx8.override {
+  kernel = pkgs.linux_imx8_kvmsed.override {
     structuredExtraConfig = with lib.kernel; {
       EFI_STUB=yes;
       EFI=yes;

--- a/img/imx8qm/default.nix
+++ b/img/imx8qm/default.nix
@@ -13,9 +13,6 @@ let
   kvms = pkgs.kvms;
 
   kvers = "${kernel.version}";
-  v = builtins.splitVersion kvers;
-  f = i: builtins.elemAt v i;
-  kv = f 0 + ''.'' + f 1;
 in
 
 with pkgs;
@@ -42,7 +39,7 @@ stdenvNoCC.mkDerivation {
     ')
     mcopy -no -i spectrum-live-imx8qm.img@@$ESP_OFFSET ${kernel}/dtbs/freescale/imx8qm-mek-hdmi.dtb ::/
     mcopy -no -i spectrum-live-imx8qm.img@@$ESP_OFFSET ${pkgs.imx-firmware}/hdmitxfw.bin ::/
-    mcopy -no -i spectrum-live-imx8qm.img@@$ESP_OFFSET ${kvms.src}/platform/nxp/imx8qm/${kv}/bl1.bin ::/
+    mcopy -no -i spectrum-live-imx8qm.img@@$ESP_OFFSET ${kvms.src}/platform/nxp/imx8qm/${kvers}/bl1.bin ::/
     mv spectrum-live-imx8qm.img $out
   '';
 }

--- a/img/imx8qm/default.nix
+++ b/img/imx8qm/default.nix
@@ -11,6 +11,11 @@ let
   spectrum = import ../live { inherit pkgs; };
   kernel = spectrum.rootfs.kernel;
   kvms = pkgs.kvms;
+
+  kvers = "${kernel.version}";
+  v = builtins.splitVersion kvers;
+  f = i: builtins.elemAt v i;
+  kv = f 0 + ''.'' + f 1;
 in
 
 with pkgs;
@@ -37,7 +42,7 @@ stdenvNoCC.mkDerivation {
     ')
     mcopy -no -i spectrum-live-imx8qm.img@@$ESP_OFFSET ${kernel}/dtbs/freescale/imx8qm-mek-hdmi.dtb ::/
     mcopy -no -i spectrum-live-imx8qm.img@@$ESP_OFFSET ${pkgs.imx-firmware}/hdmitxfw.bin ::/
-    mcopy -no -i spectrum-live-imx8qm.img@@$ESP_OFFSET ${kvms.src}/platform/nxp/imx8qxp/bl1.bin ::/
+    mcopy -no -i spectrum-live-imx8qm.img@@$ESP_OFFSET ${kvms.src}/platform/nxp/imx8qm/${kv}/bl1.bin ::/
     mv spectrum-live-imx8qm.img $out
   '';
 }

--- a/img/imx8qm/default.nix
+++ b/img/imx8qm/default.nix
@@ -10,6 +10,7 @@ let
   uboot = pkgs.ubootIMX8QM;
   spectrum = import ../live { inherit pkgs; };
   kernel = spectrum.rootfs.kernel;
+  kvms = pkgs.kvms;
 in
 
 with pkgs;
@@ -36,6 +37,7 @@ stdenvNoCC.mkDerivation {
     ')
     mcopy -no -i spectrum-live-imx8qm.img@@$ESP_OFFSET ${kernel}/dtbs/freescale/imx8qm-mek-hdmi.dtb ::/
     mcopy -no -i spectrum-live-imx8qm.img@@$ESP_OFFSET ${pkgs.imx-firmware}/hdmitxfw.bin ::/
+    mcopy -no -i spectrum-live-imx8qm.img@@$ESP_OFFSET ${kvms.src}/platform/nxp/imx8qxp/bl1.bin ::/
     mv spectrum-live-imx8qm.img $out
   '';
 }

--- a/img/imx8qxp/default.nix
+++ b/img/imx8qxp/default.nix
@@ -10,6 +10,7 @@ let
   uboot = pkgs.ubootIMX8QXP;
   spectrum = import ../live { inherit pkgs; };
   kernel = spectrum.rootfs.kernel;
+  kvms = pkgs.kvms;
 in
 
 with pkgs;
@@ -35,6 +36,7 @@ stdenvNoCC.mkDerivation {
       .sectorsize * (.partitions[] | select(.type == ESP_GUID) | .start)
     ')
     mcopy -no -i spectrum-live-imx8qxp.img@@$ESP_OFFSET ${kernel}/dtbs/freescale/imx8qxp-mek.dtb ::/
+    mcopy -no -i spectrum-live-imx8qxp.img@@$ESP_OFFSET ${kvms.src}/platform/nxp/imx8qxp/bl1.bin ::/
     mv spectrum-live-imx8qxp.img $out
   '';
 }

--- a/img/imx8qxp/default.nix
+++ b/img/imx8qxp/default.nix
@@ -11,6 +11,11 @@ let
   spectrum = import ../live { inherit pkgs; };
   kernel = spectrum.rootfs.kernel;
   kvms = pkgs.kvms;
+
+  kvers = "${kernel.version}";
+  v = builtins.splitVersion kvers;
+  f = i: builtins.elemAt v i;
+  kv = f 0 + ''.'' + f 1;
 in
 
 with pkgs;
@@ -36,7 +41,7 @@ stdenvNoCC.mkDerivation {
       .sectorsize * (.partitions[] | select(.type == ESP_GUID) | .start)
     ')
     mcopy -no -i spectrum-live-imx8qxp.img@@$ESP_OFFSET ${kernel}/dtbs/freescale/imx8qxp-mek.dtb ::/
-    mcopy -no -i spectrum-live-imx8qxp.img@@$ESP_OFFSET ${kvms.src}/platform/nxp/imx8qxp/bl1.bin ::/
+    mcopy -no -i spectrum-live-imx8qxp.img@@$ESP_OFFSET ${kvms.src}/platform/nxp/imx8qxp/${kv}/bl1.bin ::/
     mv spectrum-live-imx8qxp.img $out
   '';
 }

--- a/img/imx8qxp/default.nix
+++ b/img/imx8qxp/default.nix
@@ -13,9 +13,6 @@ let
   kvms = pkgs.kvms;
 
   kvers = "${kernel.version}";
-  v = builtins.splitVersion kvers;
-  f = i: builtins.elemAt v i;
-  kv = f 0 + ''.'' + f 1;
 in
 
 with pkgs;
@@ -41,7 +38,7 @@ stdenvNoCC.mkDerivation {
       .sectorsize * (.partitions[] | select(.type == ESP_GUID) | .start)
     ')
     mcopy -no -i spectrum-live-imx8qxp.img@@$ESP_OFFSET ${kernel}/dtbs/freescale/imx8qxp-mek.dtb ::/
-    mcopy -no -i spectrum-live-imx8qxp.img@@$ESP_OFFSET ${kvms.src}/platform/nxp/imx8qxp/${kv}/bl1.bin ::/
+    mcopy -no -i spectrum-live-imx8qxp.img@@$ESP_OFFSET ${kvms.src}/platform/nxp/imx8qxp/${kvers}/bl1.bin ::/
     mv spectrum-live-imx8qxp.img $out
   '';
 }


### PR DESCRIPTION
There is necessity to use kernel patched specifically for a kvms usage. Without kvms binary image the patched kernel will get fail to be run. That the reason why another kernel should be added.

Signed-off-by: Grigoriy Romanov <grigoriy.romanov@unikie.com>