### PR TITLE
Synchronize aarch64-imx8-crosscompile and aarch64-imx8 branches

### DIFF
--- a/host/initramfs/Makefile
+++ b/host/initramfs/Makefile
@@ -62,6 +62,7 @@ build/live.img: $(SCRIPTS)/format-uuid.sh $(SCRIPTS)/make-gpt.sh build/rootfs.ve
 clean:
 	rm -rf build
 .PHONY: clean
+extfs: $(EXT_FS)
 
 run: build/initramfs build/rootfs.verity.roothash build/live.img
 	$(QEMU_KVM) -m 4G \

--- a/host/initramfs/default.nix
+++ b/host/initramfs/default.nix
@@ -17,8 +17,7 @@ let
 
   modules = makeModulesClosure {
     inherit (rootfs) firmware kernel;
-    rootModules = with rootfs.nixosAllHardware.config.boot.initrd;
-      availableKernelModules ++ kernelModules ++ [ "dm-verity" "loop" ];
+    rootModules = [ "dm-verity" "loop" ];
   };
 
   packages = [

--- a/host/rootfs/Makefile
+++ b/host/rootfs/Makefile
@@ -9,10 +9,9 @@ QEMU_KVM = qemu-kvm
 
 # tar2ext4 will leave half a filesystem behind if it's interrupted
 # half way through.
-build/rootfs.ext4: build/rootfs.tar $(EXT_FS)
+build/rootfs.ext4: build/rootfs.tar
 	tar2ext4 -i build/rootfs.tar -o $@.tmp
 	mv $@.tmp $@
-	cp -f $(EXT_FS) build/extfs.ext4
 
 FILES = \
 	etc/fonts/fonts.conf \

--- a/host/rootfs/Makefile
+++ b/host/rootfs/Makefile
@@ -9,9 +9,10 @@ QEMU_KVM = qemu-kvm
 
 # tar2ext4 will leave half a filesystem behind if it's interrupted
 # half way through.
-build/rootfs.ext4: build/rootfs.tar
+build/rootfs.ext4: build/rootfs.tar $(EXT_FS)
 	tar2ext4 -i build/rootfs.tar -o $@.tmp
 	mv $@.tmp $@
+	cp -f $(EXT_FS) build/extfs.ext4
 
 FILES = \
 	etc/fonts/fonts.conf \
@@ -118,7 +119,7 @@ clean:
 	rm -rf build
 .PHONY: clean
 
-run: build/rootfs.ext4 $(EXT_FS)
+run: build/rootfs.ext4
 	$(QEMU_KVM) -cpu host -m 2G \
 	    -machine q35,kernel=$(KERNEL),kernel-irqchip=split \
 	    -display gtk,gl=on \

--- a/host/rootfs/default.nix
+++ b/host/rootfs/default.nix
@@ -52,6 +52,8 @@ let
 
   kernel = pkgs.linux_imx8.override {
     structuredExtraConfig = with lib.kernel; {
+      EFI_STUB=yes;
+      EFI=yes;
       VIRTIO = yes;
       VIRTIO_PCI = yes;
       VIRTIO_BLK = yes;

--- a/host/start-vm/start-vm.rs
+++ b/host/start-vm/start-vm.rs
@@ -29,7 +29,7 @@ fn vm_command(dir: PathBuf) -> Result<Command, String> {
     command.args(&["-dc", "test -S env/cloud-hypervisor.sock"]);
     command.arg("cloud-hypervisor");
     command.args(&["--api-socket", "env/cloud-hypervisor.sock"]);
-    command.args(&["--cmdline", "console=ttyS0 root=/dev/vda"]);
+    command.args(&["--cmdline", "console=hvc0 root=/dev/vda"]);
     command.args(&["--memory", "size=128M"]);
     command.args(&["--console", "pty"]);
 
@@ -72,7 +72,7 @@ fn vm_command(dir: PathBuf) -> Result<Command, String> {
     command.arg("--kernel").arg({
         let mut kernel = OsString::from("/ext/svc/data/");
         kernel.push(&vm_name);
-        kernel.push("/vmlinux");
+        kernel.push("/Image");
         kernel
     });
 

--- a/img/imx8qm/default.nix
+++ b/img/imx8qm/default.nix
@@ -1,10 +1,6 @@
 # SPDX-FileCopyrightText: 2022 Unikie
 
-{ pkgs ? import <nixpkgs> {
-    crossSystem = {
-      config = "aarch64-unknown-linux-musl";
-    };
-  }}:
+{ pkgs ? import <nixpkgs> {} }:
 
 let
   uboot = pkgs.ubootIMX8QM;

--- a/img/imx8qm/default.nix
+++ b/img/imx8qm/default.nix
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2022 Unikie
+
+{ pkgs ? import <nixpkgs> {
+    crossSystem = {
+      config = "aarch64-unknown-linux-musl";
+    };
+  }}:
+
+let
+  uboot = pkgs.ubootIMX8QM;
+  spectrum = import ../live { inherit pkgs; };
+  kernel = spectrum.rootfs.kernel;
+in
+
+with pkgs;
+
+stdenvNoCC.mkDerivation {
+  pname = "spectrum-live-imx8qm.img";
+  version = "0.1";
+
+  nativeBuildInputs = [
+    pkgsBuildHost.util-linux
+    pkgsBuildHost.jq
+    pkgsBuildHost.mtools
+  ];
+
+  buildCommand = ''
+    install -m 0644 ${spectrum} spectrum-live-imx8qm.img
+    dd if=${uboot}/flash.bin of=spectrum-live-imx8qm.img bs=1k seek=32 conv=notrunc
+    IMG=spectrum-live-imx8qm.img
+    ESP_OFFSET=$(sfdisk --json $IMG | jq -r '
+      # Partition type GUID identifying EFI System Partitions
+      def ESP_GUID: "C12A7328-F81F-11D2-BA4B-00A0C93EC93B";
+      .partitiontable |
+      .sectorsize * (.partitions[] | select(.type == ESP_GUID) | .start)
+    ')
+    mcopy -no -i spectrum-live-imx8qm.img@@$ESP_OFFSET ${kernel}/dtbs/freescale/imx8qm-mek-hdmi.dtb ::/
+    mcopy -no -i spectrum-live-imx8qm.img@@$ESP_OFFSET ${pkgs.imx-firmware}/hdmitxfw.bin ::/
+    mv spectrum-live-imx8qm.img $out
+  '';
+}

--- a/img/imx8qxp/default.nix
+++ b/img/imx8qxp/default.nix
@@ -1,10 +1,6 @@
 # SPDX-FileCopyrightText: 2022 Unikie
 
-{ pkgs ? import <nixpkgs> {
-    crossSystem = {
-      config = "aarch64-unknown-linux-musl";
-    };
-  }}:
+{ pkgs ? import <nixpkgs> {} }:
 
 let
   uboot = pkgs.ubootIMX8QXP;

--- a/img/imx8qxp/default.nix
+++ b/img/imx8qxp/default.nix
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2022 Unikie
+
+{ pkgs ? import <nixpkgs> {
+    crossSystem = {
+      config = "aarch64-unknown-linux-musl";
+    };
+  }}:
+
+let
+  uboot = pkgs.ubootIMX8QXP;
+  spectrum = import ../live { inherit pkgs; };
+  kernel = spectrum.rootfs.kernel;
+in
+
+with pkgs;
+
+stdenvNoCC.mkDerivation {
+  pname = "spectrum-live-imx8qxp.img";
+  version = "0.1";
+
+  nativeBuildInputs = [
+    pkgsBuildHost.util-linux
+    pkgsBuildHost.jq
+    pkgsBuildHost.mtools
+  ];
+
+  buildCommand = ''
+    install -m 0644 ${spectrum} spectrum-live-imx8qxp.img
+    dd if=${uboot}/flash.bin of=spectrum-live-imx8qxp.img bs=1k seek=32 conv=notrunc
+    IMG=spectrum-live-imx8qxp.img
+    ESP_OFFSET=$(sfdisk --json $IMG | jq -r '
+      # Partition type GUID identifying EFI System Partitions
+      def ESP_GUID: "C12A7328-F81F-11D2-BA4B-00A0C93EC93B";
+      .partitiontable |
+      .sectorsize * (.partitions[] | select(.type == ESP_GUID) | .start)
+    ')
+    mcopy -no -i spectrum-live-imx8qxp.img@@$ESP_OFFSET ${kernel}/dtbs/freescale/imx8qxp-mek.dtb ::/
+    mv spectrum-live-imx8qxp.img $out
+  '';
+}

--- a/img/live/default.nix
+++ b/img/live/default.nix
@@ -26,7 +26,7 @@ stdenvNoCC.mkDerivation {
     src = cleanSource ./.;
   };
 
-  nativeBuildInputs = [ cryptsetup dosfstools jq mtools util-linux ];
+  nativeBuildInputs = [ pkgsBuildHost.cryptsetup pkgsBuildHost.dosfstools pkgsBuildHost.jq pkgsBuildHost.mtools pkgsBuildHost.util-linux ];
 
   EXT_FS = extfs;
   INITRAMFS = initramfs;
@@ -44,4 +44,6 @@ stdenvNoCC.mkDerivation {
   '';
 
   enableParallelBuilding = true;
+
+  passthru = { inherit rootfs; };
 }

--- a/scripts/make-gpt.sh
+++ b/scripts/make-gpt.sh
@@ -1,12 +1,13 @@
 #!/bin/sh -eu
 #
 # SPDX-FileCopyrightText: 2021-2022 Alyssa Ross <hi@alyssa.is>
+# SPDX-FileCopyrightText: 2022 Unikie
 # SPDX-License-Identifier: EUPL-1.2+
 #
 # usage: make-gpt.sh GPT_PATH PATH:PARTTYPE[:PARTUUID]...
 
 ONE_MiB=1048576
-TWO_MiB=2097152
+NINE_MiB=9437184
 
 # Prints the number of 1MiB blocks required to store the file named
 # $1.  We use 1MiB blocks because that's what sfdisk uses for
@@ -41,8 +42,9 @@ shift
 nl=$'\n'
 table="label: gpt"
 
-# Keep 1MiB free at the start, and 1MiB free at the end.
-gptBytes=$TWO_MiB
+# Keep 8MiB free at the start (to provide space for firmware if
+# required), and 1MiB free at the end.
+gptBytes=$NINE_MiB
 for partition; do
 	sizeMiB="$(sizeMiB "$(partitionPath "$partition")")"
 	table="$table${nl}size=${sizeMiB}MiB,$(awk -f "$scriptsDir/sfdisk-field.awk" -v partition="$partition")"
@@ -52,6 +54,7 @@ done
 rm -f "$out"
 truncate -s "$gptBytes" "$out"
 sfdisk "$out" <<EOF
+first-lba: 16384
 $table
 EOF
 

--- a/vm/app/catgirl/Makefile
+++ b/vm/app/catgirl/Makefile
@@ -13,7 +13,7 @@ HOST_FILES = host/data/appvm-catgirl/providers/net/netvm
 
 HOST_BUILD_FILES = \
 	build/host/data/appvm-catgirl/rootfs.ext4 \
-	build/host/data/appvm-catgirl/vmlinux
+	build/host/data/appvm-catgirl/Image
 
 # We produce a directory, but that doesn't play nice with Make,
 # because it won't know to update if some file in the directory is
@@ -29,9 +29,9 @@ build/svc: $(HOST_FILES) $(HOST_BUILD_FILES)
 	tar -c $(HOST_FILES) | tar -C $@ -x --strip-components 1
 	tar -c $(HOST_BUILD_FILES) | tar -C $@ -x --strip-components 2
 
-build/host/data/appvm-catgirl/vmlinux: $(VMLINUX)
+build/host/data/appvm-catgirl/Image: $(IMAGE)
 	mkdir -p $$(dirname $@)
-	cp $(VMLINUX) $@
+	cp $(IMAGE) $$(dirname $@)/Image
 
 # tar2ext4 will leave half a filesystem behind if it's interrupted
 # half way through.

--- a/vm/app/catgirl/default.nix
+++ b/vm/app/catgirl/default.nix
@@ -47,8 +47,10 @@ let
         -T ${writeReferencesToFile packagesSysroot} .
   '';
 
-  kernel = buildPackages.linux.override {
+  kernel = pkgs.linux_latest.override {
     structuredExtraConfig = with lib.kernel; {
+      EFI_STUB=yes;
+      EFI=yes;
       VIRTIO = yes;
       VIRTIO_PCI = yes;
       VIRTIO_BLK = yes;
@@ -75,6 +77,7 @@ stdenvNoCC.mkDerivation {
 
   PACKAGES_TAR = packagesTar;
   VMLINUX = "${kernel.dev}/vmlinux";
+  IMAGE = "${kernel}/Image";
 
   installPhase = ''
     mv build/svc $out

--- a/vm/app/lynx/Makefile
+++ b/vm/app/lynx/Makefile
@@ -13,7 +13,7 @@ HOST_FILES = host/data/appvm-lynx/providers/net/netvm
 
 HOST_BUILD_FILES = \
 	build/host/data/appvm-lynx/rootfs.ext4 \
-	build/host/data/appvm-lynx/vmlinux
+	build/host/data/appvm-lynx/Image
 
 # We produce a directory, but that doesn't play nice with Make,
 # because it won't know to update if some file in the directory is
@@ -29,9 +29,9 @@ build/svc: $(HOST_FILES) $(HOST_BUILD_FILES)
 	tar -c $(HOST_FILES) | tar -C $@ -x --strip-components 1
 	tar -c $(HOST_BUILD_FILES) | tar -C $@ -x --strip-components 2
 
-build/host/data/appvm-lynx/vmlinux: $(VMLINUX)
+build/host/data/appvm-lynx/Image: $(IMAGE)
 	mkdir -p $$(dirname $@)
-	cp $(VMLINUX) $@
+	cp $(IMAGE) $$(dirname $@)/Image
 
 # tar2ext4 will leave half a filesystem behind if it's interrupted
 # half way through.

--- a/vm/app/lynx/default.nix
+++ b/vm/app/lynx/default.nix
@@ -47,8 +47,10 @@ let
         -T ${writeReferencesToFile packagesSysroot} .
   '';
 
-  kernel = buildPackages.linux.override {
+  kernel = pkgs.linux_latest.override {
     structuredExtraConfig = with lib.kernel; {
+      EFI_STUB=yes;
+      EFI=yes;
       VIRTIO = yes;
       VIRTIO_PCI = yes;
       VIRTIO_BLK = yes;
@@ -75,6 +77,7 @@ stdenvNoCC.mkDerivation {
 
   PACKAGES_TAR = packagesTar;
   VMLINUX = "${kernel.dev}/vmlinux";
+  IMAGE = "${kernel}/Image";
 
   installPhase = ''
     mv build/svc $out

--- a/vm/sys/net/Makefile
+++ b/vm/sys/net/Makefile
@@ -11,7 +11,7 @@ VMM = qemu
 
 HOST_BUILD_FILES = \
 	build/host/data/netvm/rootfs.ext4 \
-	build/host/data/netvm/vmlinux
+	build/host/data/netvm/Image
 
 # We produce a directory, but that doesn't play nice with Make,
 # because it won't know to update if some file in the directory is
@@ -26,9 +26,9 @@ build/svc: $(HOST_BUILD_FILES)
 
 	tar -c $(HOST_BUILD_FILES) | tar -C $@ -x --strip-components 2
 
-build/host/data/netvm/vmlinux: $(VMLINUX)
+build/host/data/netvm/Image: $(IMAGE)
 	mkdir -p $$(dirname $@)
-	cp $(VMLINUX) $@
+	cp $(IMAGE) $$(dirname $@)/Image
 
 # tar2ext4 will leave half a filesystem behind if it's interrupted
 # half way through.

--- a/vm/sys/net/default.nix
+++ b/vm/sys/net/default.nix
@@ -56,8 +56,10 @@ let
         -T ${writeReferencesToFile packagesSysroot} .
   '';
 
-  kernel = buildPackages.linux.override {
+  kernel = pkgs.linux_latest.override {
     structuredExtraConfig = with lib.kernel; {
+      EFI_STUB=yes;
+      EFI=yes;
       VIRTIO = yes;
       VIRTIO_PCI = yes;
       VIRTIO_BLK = yes;
@@ -84,6 +86,7 @@ stdenvNoCC.mkDerivation {
 
   PACKAGES_TAR = packagesTar;
   VMLINUX = "${kernel.dev}/vmlinux";
+  IMAGE = "${kernel}/Image";
 
   installPhase = ''
     mv build/svc $out


### PR DESCRIPTION
This copies all relevant commits from aarch64-imx8-crosscompile to aarch64-imx8 so that we can build the same images both on the ARM server and on x64 using cross compilation. These is needed for development purposes when something fails to cross compile but builds fine on ARM.