### PR TITLE
host/rootfs: fix mounting of the ext partition

### DIFF
--- a/host/rootfs/etc/mdev/block/add
+++ b/host/rootfs/etc/mdev/block/add
@@ -18,8 +18,7 @@ backtick -E ext {
     backtick -E diskpath {
       pipeline { lsblk -lnpo KNAME,PKNAME }
       backtick -E rootpart {
-        pipeline { veritysetup status root-verity }
-        awk -F ":[[:blank:]]*" "$1 ~ /^[[:blank:]]*data device$/ {print $2; exit}"
+        readlink /dev/rootfs
       }
       awk -v rootpart=${rootpart} "$1 == rootpart {print $2; exit}"
     }


### PR DESCRIPTION
When the root filesystem is mounted in read-write mode the ext partition doesn't mount correctly and appvm commands hang indefinitely. This fixes that issue.

Signed-off-by: Yuri Nesterov <yuriy.nesterov@unikie.com>