### PR TITLE
 host/rootfs: change host kernel to linux_imx8

### DIFF
--- a/host/rootfs/default.nix
+++ b/host/rootfs/default.nix
@@ -73,7 +73,17 @@ let
     imports = [ (modulesPath + "/profiles/all-hardware.nix") ];
   });
 
-  kernel = pkgs.linux_latest;
+  kernel = pkgs.linux_imx8.override {
+    structuredExtraConfig = with lib.kernel; {
+      ATA_PIIX = yes;
+      EFI_STUB = yes;
+      EFI = yes;
+      VIRTIO = yes;
+      VIRTIO_PCI = yes;
+      VIRTIO_BLK = yes;
+      EXT4_FS = yes;
+    };
+  };
 
   appvm = import ../../img/app {
     inherit config;


### PR DESCRIPTION
For imx8qm and imx8qxp boards we need to use linux_imx8 kernel. We can't override linux_latest because app vms require at least 5.16 for wayland support while linux_imx8 is 5.15 at the moment.

Signed-off-by: Yuri Nesterov <yuriy.nesterov@unikie.com>