### PR TITLE
host/rootfs: get rid of virgl from crosvm command line

### DIFF
--- a/host/rootfs/etc/template/gpu/run
+++ b/host/rootfs/etc/template/gpu/run
@@ -6,4 +6,4 @@ s6-notifyoncheck -d
 crosvm --no-syslog device gpu
   --socket env/crosvm.sock
   --wayland-sock /run/user/0/wayland-1
-  --params "{\"context-types\": \"virgl:virgl2:cross-domain\"}"
+  --params "{\"context-types\": \"cross-domain\"}"


### PR DESCRIPTION
This option is only used when running under qemu. It can't be used when running on imx8qm device.

Signed-off-by: Yuri Nesterov <yuriy.nesterov@unikie.com>