### PR TITLE
This PR adds apps into the host as well as a couple of appVMs

### DIFF
--- a/README
+++ b/README
@@ -1,2 +1,25 @@
 The canonical URL for the upstream Spectrum git repository is
 <https://spectrum-os.org/git/spectrum/>.
+
+QVT for sound and camera:
+
+When booted, run `cat /proc/asound/cards` and find the number of your sound device there.
+
+Check if there is a correct configuration in /etc/asound.conf file:
+```
+...
+slave {
+    pcm "hw:3,0" <- Set here ID of device,as in cat /proc/asound/cards
+...
+ctl.dmixer {
+        type hw
+        card 3 <- Set here ID of device,as in cat /proc/asound/cards
+}
+```
+To test sound, run
+`speaker-test -c2`
+You should hear a (white?) noise.
+
+The easiest way to test camera is to visit https://webcamtests.com/ service.
+Remember to configure networking and set correct time in prior.
+

--- a/host/initramfs/extfs.nix
+++ b/host/initramfs/extfs.nix
@@ -14,6 +14,8 @@ let
   appvm-lynx = import ../../vm/app/lynx.nix { inherit config; };
   appvm-usbapp = import ../../vm/app/usbapp.nix { inherit config; };
   appvm-usb = import ../../vm/app/usb { inherit config; };
+  appvm-foot = import ../../vm/app/foot-vm.nix {inherit config;};
+  appvm-zathura = import ../../vm/app/zathura-vm.nix {inherit config;};
 
 in
 
@@ -33,7 +35,10 @@ runCommand "ext.ext4" {
   tar -C ${appvm-usbapp} -c data | tar -C svc -x
   chmod +w svc/data
   tar -C ${appvm-usb} -c data | tar -C svc -x
-
+  chmod +w svc/data
+  tar -C ${appvm-foot} -c data | tar -C svc -x
+  chmod +w svc/data
+  tar -C ${appvm-zathura} -c data | tar -C svc -x
 
 
   tar -cf ext.tar svc

--- a/host/rootfs/Makefile
+++ b/host/rootfs/Makefile
@@ -47,6 +47,7 @@ FILES = \
 	etc/xdg/weston/weston.ini \
 	usr/bin/usb-export \
 	usr/bin/__e \
+	usr/bin/setup.sh \
 	usr/bin/lsvm \
 	usr/bin/vm-console \
 	usr/bin/vm-start \

--- a/host/rootfs/Makefile
+++ b/host/rootfs/Makefile
@@ -20,6 +20,7 @@ build/rootfs.ext4: build/rootfs.tar
 	mv $@.tmp $@
 
 FILES = \
+	etc/asound.conf \
 	etc/fonts/fonts.conf \
 	etc/fstab \
 	etc/group \

--- a/host/rootfs/default.nix
+++ b/host/rootfs/default.nix
@@ -96,7 +96,7 @@ let
 
   # Packages that should be fully linked into /usr,
   # (not just their bin/* files).
-  usrPackages = [ appvm pkgsGui.mesa.drivers pkgsGui.dejavu_fonts pkgs.element-desktop-wayland pkgs.firefox-wayland ];
+  usrPackages = [ appvm pkgsGui.mesa.drivers pkgsGui.dejavu_fonts pkgs.element-desktop-wayland pkgs.chromium ];
 
   packagesSysroot = runCommand "packages-sysroot" {
     nativeBuildInputs = [ xorg.lndir ];

--- a/host/rootfs/default.nix
+++ b/host/rootfs/default.nix
@@ -6,7 +6,7 @@
 pkgs.callPackage (
 
 { lib, stdenvNoCC, nixos, runCommand, writeReferencesToFile, s6-rc, tar2ext4
-, busybox, cloud-hypervisor, cryptsetup, execline, jq, kmod
+, busybox, cloud-hypervisor, cryptsetup, execline, jq, kmod, cacert
 , mdevd, s6, s6-linux-init, socat, util-linuxMinimal, xorg, strace, e2fsprogs, usbutils
 }:
 
@@ -45,7 +45,7 @@ let
 
   packages = [
     cloud-hypervisor pkgs.crosvm execline jq kmod mdevd s6 s6-linux-init s6-rc
-    socat start-vm strace
+    socat start-vm strace cacert
 
     (cryptsetup.override {
       programs = {
@@ -96,7 +96,7 @@ let
 
   # Packages that should be fully linked into /usr,
   # (not just their bin/* files).
-  usrPackages = [ appvm pkgsGui.mesa.drivers pkgsGui.dejavu_fonts pkgs.element-desktop-wayland pkgs.chromium ];
+  usrPackages = [ appvm pkgsGui.mesa.drivers pkgsGui.dejavu_fonts pkgs.element-desktop-wayland pkgs.chromium pkgs.gala64 ];
 
   packagesSysroot = runCommand "packages-sysroot" {
     nativeBuildInputs = [ xorg.lndir ];
@@ -114,6 +114,8 @@ let
     # programs we want.
     # https://lore.kernel.org/util-linux/87zgrl6ufb.fsf@alyssa.is/
     ln -s ${util-linuxMinimal}/bin/{findfs,lsblk} $out/usr/bin
+    mkdir -p $out/etc/ssl/certs
+    cp -r ${cacert}/etc/ssl/certs/ca-bundle.crt $out/etc/ssl/certs/ca-certificates.crt
   '';
 
   packagesTar = runCommand "packages.tar" {} ''

--- a/host/rootfs/default.nix
+++ b/host/rootfs/default.nix
@@ -6,7 +6,7 @@
 pkgs.callPackage (
 
 { lib, stdenvNoCC, nixos, runCommand, writeReferencesToFile, s6-rc, tar2ext4
-, busybox, cloud-hypervisor, cryptsetup, execline, jq, kmod, cacert
+, busybox, cloud-hypervisor, cryptsetup, execline, jq, kmod, cacert, alsa-utils
 , mdevd, s6, s6-linux-init, socat, util-linuxMinimal, xorg, strace, e2fsprogs, usbutils
 }:
 
@@ -45,7 +45,7 @@ let
 
   packages = [
     cloud-hypervisor pkgs.crosvm execline jq kmod mdevd s6 s6-linux-init s6-rc
-    socat start-vm strace cacert
+    socat start-vm strace cacert alsa-utils
 
     (cryptsetup.override {
       programs = {

--- a/host/rootfs/default.nix
+++ b/host/rootfs/default.nix
@@ -3,11 +3,11 @@
 # SPDX-FileCopyrightText: 2022 Unikie
 
 { config ? import ../../nix/eval-config.nix {} }: let inherit (config) pkgs; in
-pkgs.pkgsStatic.callPackage (
+pkgs.callPackage (
 
-{ lib, stdenvNoCC, nixos, runCommand, buildPackages, writeReferencesToFile, s6-rc, tar2ext4
+{ lib, stdenvNoCC, nixos, runCommand, writeReferencesToFile, s6-rc, tar2ext4
 , busybox, cloud-hypervisor, cryptsetup, execline, jq, kmod
-, mdevd, s6, s6-linux-init, socat, util-linuxMinimal, xorg, e2fsprogs, usbutils
+, mdevd, s6, s6-linux-init, socat, util-linuxMinimal, xorg, strace, e2fsprogs, usbutils
 }:
 
 let
@@ -45,7 +45,7 @@ let
 
   packages = [
     cloud-hypervisor pkgs.crosvm execline jq kmod mdevd s6 s6-linux-init s6-rc
-    socat start-vm
+    socat start-vm strace
 
     (cryptsetup.override {
       programs = {
@@ -96,7 +96,7 @@ let
 
   # Packages that should be fully linked into /usr,
   # (not just their bin/* files).
-  usrPackages = [ appvm pkgsGui.mesa.drivers pkgsGui.dejavu_fonts ];
+  usrPackages = [ appvm pkgsGui.mesa.drivers pkgsGui.dejavu_fonts pkgs.element-desktop-wayland pkgs.firefox-wayland ];
 
   packagesSysroot = runCommand "packages-sysroot" {
     nativeBuildInputs = [ xorg.lndir ];

--- a/host/rootfs/etc/asound.conf
+++ b/host/rootfs/etc/asound.conf
@@ -1,0 +1,34 @@
+pcm.!default {
+        type plug
+        slave.pcm "asymed"
+}
+
+
+pcm.dmixer  {
+        type dmix
+        ipc_key 1024
+        slave {
+                pcm "hw:0,0"
+                period_time 0
+                period_size 1024
+                buffer_size 4096
+                rate 44100
+		channels 2
+        }
+        bindings {
+                0 0
+                1 1
+        }
+}
+
+pcm.asymed {
+        type asym
+        playback.pcm "dmixer"
+        capture.pcm "hw:0,0"
+}
+
+ctl.dmixer {
+        type hw
+        card 0
+}
+

--- a/host/rootfs/usr/bin/setup.sh
+++ b/host/rootfs/usr/bin/setup.sh
@@ -5,27 +5,22 @@ export WAYLAND_DISPLAY=wayland-1
 export XDG_RUNTIME_DIR=/run/user/0
 export WESTON_CONFIG_FILE=/etc/xdg/weston/weston.ini
 
-export MESA_DEBUG=1
-export EGL_LOG_LEVEL=debug
-export LIBGL_DEBUG=verbose
-export WAYLAND_DEBUG=1
-
-export ELECTRON_ENABLE_LOGGING=true
-export ELECTRON_DEBUG_NOTIFICATIONS=true
-export ELECTRON_ENABLE_STACK_DUMPING=true
-
-mkdir -p /home
+echo "12345678901264758695847364857456" > /etc/machine-id
+mkdir -p /home/apprunner
+mkdir /tmp && chmod 0777 /tmp
 adduser apprunner -D -h /home/apprunner
 chown apprunner:apprunner /home/apprunner
-mkdir /tmp && chmod 0777 /tmp
-chmod 666 /dev/null
 chown -R apprunner:apprunner /run/user/0
+chown apprunner /dev/pts/0
 chmod -R 0755 /run/user/0
-echo "12345678901264758695847364857456" > /etc/machine-id
+chmod 666 /dev/null
+chmod 666 /dev/urandom
+chmod 666 /dev/tty
 chmod 666 /dev/dri/card0
 chmod 666 /dev/dri/renderD128
 
-
-# /nix/store/2c0446iag7gf6gb96ka3283gx56zyfry-electron-12.2.3/bin/electron --enable-features=UseOzonePlatform --ozone-platform=wayland
-
 # element-desktop  --enable-features=UseOzonePlatform --ozone-platform=wayland
+
+# /nix/store/npknxl8a5lnc451pj3c2sqbpl5qdri5a-electron-19.0.7/bin/electron --enable-features=UseOzonePlatform --ozone-platform=wayland
+
+# chromium --enable-features=UseOzonePlatform --ozone-platform=wayland

--- a/host/rootfs/usr/bin/setup.sh
+++ b/host/rootfs/usr/bin/setup.sh
@@ -19,8 +19,16 @@ chmod 666 /dev/tty
 chmod 666 /dev/dri/card0
 chmod 666 /dev/dri/renderD128
 
-# element-desktop  --enable-features=UseOzonePlatform --ozone-platform=wayland
+echo "element-desktop  --enable-features=UseOzonePlatform --ozone-platform=wayland" > /home/apprunner/element-desktop.sh
+chown apprunner /home/apprunner/element-desktop.sh
+chmod +x /home/apprunner/element-desktop.sh
+
+echo "chromium  --enable-features=UseOzonePlatform --ozone-platform=wayland" > /home/apprunner/chromium.sh
+chown apprunner /home/apprunner/chromium.sh
+chmod +x /home/apprunner/chromium.sh
+
+echo "gala  --enable-features=UseOzonePlatform --ozone-platform=wayland" > /home/apprunner/gala.sh
+chown apprunner /home/apprunner/gala.sh
+chmod +x /home/apprunner/gala.sh
 
 # /nix/store/npknxl8a5lnc451pj3c2sqbpl5qdri5a-electron-19.0.7/bin/electron --enable-features=UseOzonePlatform --ozone-platform=wayland
-
-# chromium --enable-features=UseOzonePlatform --ozone-platform=wayland

--- a/host/rootfs/usr/bin/setup.sh
+++ b/host/rootfs/usr/bin/setup.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: 2022 Unikie>
+
+export WAYLAND_DISPLAY=wayland-1
+export XDG_RUNTIME_DIR=/run/user/0
+export WESTON_CONFIG_FILE=/etc/xdg/weston/weston.ini
+
+export MESA_DEBUG=1
+export EGL_LOG_LEVEL=debug
+export LIBGL_DEBUG=verbose
+export WAYLAND_DEBUG=1
+
+export ELECTRON_ENABLE_LOGGING=true
+export ELECTRON_DEBUG_NOTIFICATIONS=true
+export ELECTRON_ENABLE_STACK_DUMPING=true
+
+mkdir -p /home
+adduser apprunner -D -h /home/apprunner
+chown apprunner:apprunner /home/apprunner
+mkdir /tmp && chmod 0777 /tmp
+chmod 666 /dev/null
+chown -R apprunner:apprunner /run/user/0
+chmod -R 0755 /run/user/0
+echo "12345678901264758695847364857456" > /etc/machine-id
+chmod 666 /dev/dri/card0
+chmod 666 /dev/dri/renderD128
+
+
+# /nix/store/2c0446iag7gf6gb96ka3283gx56zyfry-electron-12.2.3/bin/electron --enable-features=UseOzonePlatform --ozone-platform=wayland
+
+# element-desktop  --enable-features=UseOzonePlatform --ozone-platform=wayland

--- a/vm/app/foot-vm.nix
+++ b/vm/app/foot-vm.nix
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2022 Alyssa Ross <hi@alyssa.is><
+# SPDX-FileCopyrightText: 2022 Unikie
+
+{ config }:
+
+import ../../vm-lib/make-vm.nix { inherit config; } {
+    name = "appvm-foot";
+    wayland = true;
+    run = config.pkgs.callPackage (
+      { writeScript, foot, wayland-proxy-virtwl }:
+      writeScript "appvm-foot-run" ''
+        #!/bin/execlineb -P
+        if { modprobe virtio-gpu }
+        foreground { ln -ns /run/ext /run/opengl-driver }
+        foreground { mkdir /run/user }
+        foreground {
+          umask 077
+          mkdir /run/user/0
+        }
+        export XDG_RUNTIME_DIR /run/user/0
+        ${wayland-proxy-virtwl}/bin/wayland-proxy-virtwl --virtio-gpu
+        ${foot}/bin/foot
+      ''
+    ) {};
+}

--- a/vm/app/zathura-vm.nix
+++ b/vm/app/zathura-vm.nix
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2022 Unikie
+
+{ config ? import ../../../nix/eval-config.nix {} }:
+
+import ../../vm-lib/make-vm.nix { inherit config; } {
+  name = "appvm-zathura";
+  wayland = true;
+  run = config.pkgs.callPackage (
+    { writeScript, zathura, wayland-proxy-virtwl }:
+    writeScript "run-zathura" ''
+      #!/bin/execlineb -P
+      if { modprobe virtio-gpu }
+      foreground { ln -ns /run/ext /run/opengl-driver }
+      foreground { mkdir /run/user }
+      foreground {
+        umask 077
+        mkdir /run/user/0
+      }
+      export XDG_RUNTIME_DIR /run/user/0
+      ${wayland-proxy-virtwl}/bin/wayland-proxy-virtwl --virtio-gpu
+      ${zathura}/bin/zathura
+    ''
+  ) { };
+}


### PR DESCRIPTION
These changes are used to build the imx8qm image: /nix/store/kcs17bd10if38hx2cbdx8dka6hkpnwj7-spectrum-live-imx8qm.img-0.1
It needs gala64 app, which is added here: https://github.com/tiiuae/nixpkgs-spectrum/pull/28

Instructions:
boot the board, then
`source /usr/bin/setup.sh`
`su apprunner`
`cd`

Now, when in the `apprunner` home directory, you can see starting scripts.

Important notes: 
1. Set correct date with `date -s "2022-11-03 16:00"` as an example;
2. Connect Eth to the board and run `udhcpc -i eth0` to get correct network settings. (Make sure you have DHCP server up and running inside the connected network!)