### PR TITLE
Remove bashisms from spectrum shell scripts

### DIFF
--- a/Documentation/scripts/undocumented-uuids.sh
+++ b/Documentation/scripts/undocumented-uuids.sh
@@ -1,5 +1,6 @@
 #!/bin/sh -eu
 # SPDX-FileCopyrightText: 2022 Alyssa Ross <hi@alyssa.is>
+# SPDX-FileCopyrightText: 2022 Unikie
 # SPDX-License-Identifier: EUPL-1.2+
 
 cd "$(dirname "$0")/../.."
@@ -7,8 +8,11 @@ cd "$(dirname "$0")/../.."
 PATTERN='\b[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}\b'
 UUID_REFERENCE_PATH=Documentation/uuid-reference.adoc
 
+tmp=$(mktemp)
+grep -Eio "$PATTERN" "$UUID_REFERENCE_PATH" | sort -u >$tmp
 git ls-files -coz --exclude-standard |
     grep -Fxvz "$UUID_REFERENCE_PATH" |
     xargs -0 git grep -Ehio --no-index --no-line-number "$PATTERN" -- |
     sort -u |
-    comm -23 - <(grep -Eio "$PATTERN" "$UUID_REFERENCE_PATH" | sort -u)
+    comm -23 - $tmp
+rm -f $tmp

--- a/scripts/format-uuid.sh
+++ b/scripts/format-uuid.sh
@@ -1,6 +1,19 @@
 #!/bin/sh -eu
 #
 # SPDX-FileCopyrightText: 2021-2022 Alyssa Ross <hi@alyssa.is>
+# SPDX-FileCopyrightText: 2022 Unikie
 # SPDX-License-Identifier: EUPL-1.2+
 
-printf "%s\n" "${1:0:8}-${1:8:4}-${1:12:4}-${1:16:4}-${1:20}"
+substr () {
+    str=$1
+    beg=$2
+    end=$3
+    echo $(echo $str | cut -c $beg-$end)
+}
+
+u1=$(substr $1 1 8)
+u2=$(substr $1 9 12)
+u3=$(substr $1 13 16)
+u4=$(substr $1 17 20)
+u5=$(substr $1 21 32)
+printf "%s\n" "$u1-$u2-$u3-$u4-$u5"

--- a/scripts/make-gpt.sh
+++ b/scripts/make-gpt.sh
@@ -1,6 +1,7 @@
 #!/bin/sh -eu
 #
 # SPDX-FileCopyrightText: 2021-2022 Alyssa Ross <hi@alyssa.is>
+# SPDX-FileCopyrightText: 2022 Unikie
 # SPDX-License-Identifier: EUPL-1.2+
 #
 # usage: make-gpt.sh GPT_PATH PATH:PARTTYPE[:PARTUUID]...
@@ -38,7 +39,7 @@ scriptsDir="$(dirname "$0")"
 out="$1"
 shift
 
-nl=$'\n'
+nl='\n'
 table="label: gpt"
 
 # Keep 1MiB free at the start, and 1MiB free at the end.
@@ -51,9 +52,7 @@ done
 
 rm -f "$out"
 truncate -s "$gptBytes" "$out"
-sfdisk "$out" <<EOF
-$table
-EOF
+printf "$table" | sfdisk "$out"
 
 n=0
 for partition; do


### PR DESCRIPTION
This commit removes bashisms from spectrum shell scripts. This change is needed to be able to use the scripts from POSIX-compliant shells which are not bash compatible - such as dash.

Signed-off-by: Henri Rosten <henri.rosten@unikie.com>